### PR TITLE
fix(dex-analytics): pool tools return 410, route them to /pools/search

### DIFF
--- a/src/modules/dex-analytics/tools.ts
+++ b/src/modules/dex-analytics/tools.ts
@@ -86,11 +86,14 @@ export function registerDexAnalyticsTools(server: McpServer) {
       page: z.number().optional().default(0).describe("Page number for pagination"),
       limit: z.number().optional().default(10).describe("Results per page (max 100)"),
       sort: z.enum(["asc", "desc"]).optional().default("desc").describe("Sort order"),
-      orderBy: z.enum(["volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"])
-        .optional().default("volume_usd").describe("Field to order by")
+      orderBy: z.enum([
+        "volume_usd_24h", "volume_usd_7d", "volume_usd_30d", "liquidity_usd",
+        "txns_24h", "created_at", "price_usd",
+        "price_change_percentage_24h", "price_change_percentage_6h"
+      ]).optional().default("volume_usd_24h").describe("Field to order by")
     },
     async (params) => {
-      const endpoint = `/networks/${params.network}/pools?page=${params.page}&limit=${params.limit}&sort=${params.sort}&order_by=${params.orderBy}`
+      const endpoint = `/networks/${params.network}/pools/search?page=${params.page}&limit=${params.limit}&sort=${params.sort}&order_by=${params.orderBy}`
       const data = await dexPaprikaRequest(endpoint)
       if (!data) {
         return { content: [{ type: "text" as const, text: "Failed to fetch pools" }] }
@@ -169,19 +172,14 @@ export function registerDexAnalyticsTools(server: McpServer) {
       page: z.number().optional().default(0).describe("Page number"),
       limit: z.number().optional().default(10).describe("Results per page (max 100)"),
       sort: z.enum(["asc", "desc"]).optional().default("desc").describe("Sort order"),
-      orderBy: z.enum(["volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"])
-        .optional().default("volume_usd").describe("Field to order by"),
-      reorder: z.boolean().optional().describe("Reorder so specified token is primary"),
-      pairedWith: z.string().optional().describe("Filter pools paired with this token address")
+      orderBy: z.enum([
+        "volume_usd_24h", "volume_usd_7d", "volume_usd_30d", "liquidity_usd",
+        "txns_24h", "created_at", "price_usd",
+        "price_change_percentage_24h", "price_change_percentage_6h"
+      ]).optional().default("volume_usd_24h").describe("Field to order by")
     },
     async (params) => {
-      let endpoint = `/networks/${params.network}/tokens/${params.tokenAddress}/pools?page=${params.page}&limit=${params.limit}&sort=${params.sort}&order_by=${params.orderBy}`
-      if (params.reorder !== undefined) {
-        endpoint += `&reorder=${params.reorder}`
-      }
-      if (params.pairedWith) {
-        endpoint += `&address=${encodeURIComponent(params.pairedWith)}`
-      }
+      const endpoint = `/networks/${params.network}/pools/search?token_address=${encodeURIComponent(params.tokenAddress)}&page=${params.page}&limit=${params.limit}&sort=${params.sort}&order_by=${params.orderBy}`
       const data = await dexPaprikaRequest(endpoint)
       if (!data) {
         return { content: [{ type: "text" as const, text: "Failed to fetch token pools" }] }

--- a/src/vendors/dex-analytics/index.js
+++ b/src/vendors/dex-analytics/index.js
@@ -115,10 +115,10 @@ server.tool(
     page: z.number().optional().default(0).describe('Page number for pagination'),
     limit: z.number().optional().default(10).describe('Number of items per page (max 100)'),
     sort: z.enum(['asc', 'desc']).optional().default('desc').describe('Sort order'),
-    orderBy: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().default('volume_usd').describe('Field to order by')
+    orderBy: z.enum(['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h', 'price_change_percentage_6h']).optional().default('volume_usd_24h').describe('Field to order by')
   },
   async ({ network, page, limit, sort, orderBy }) => {
-    const data = await fetchFromAPI(`/networks/${network}/pools?page=${page}&limit=${limit}&sort=${sort}&order_by=${orderBy}`);
+    const data = await fetchFromAPI(`/networks/${network}/pools/search?page=${page}&limit=${limit}&sort=${sort}&order_by=${orderBy}`);
     return formatMcpResponse(data);
   }
 );
@@ -180,18 +180,10 @@ server.tool(
     page: z.number().optional().default(0).describe('Page number for pagination'),
     limit: z.number().optional().default(10).describe('Number of items per page (max 100)'),
     sort: z.enum(['asc', 'desc']).optional().default('desc').describe('Sort order'),
-    orderBy: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().default('volume_usd').describe('Field to order by'),
-    reorder: z.boolean().optional().describe('If true, reorders the pool so that the specified token becomes the primary token for all metrics'),
-    address: z.string().optional().describe('Filter pools that contain this additional token address')
+    orderBy: z.enum(['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h', 'price_change_percentage_6h']).optional().default('volume_usd_24h').describe('Field to order by')
   },
-  async ({ network, tokenAddress, page, limit, sort, orderBy, reorder, address }) => {
-    let endpoint = `/networks/${network}/tokens/${tokenAddress}/pools?page=${page}&limit=${limit}&sort=${sort}&order_by=${orderBy}`;
-    if (reorder !== undefined) {
-      endpoint += `&reorder=${reorder}`;
-    }
-    if (address) {
-      endpoint += `&address=${encodeURIComponent(address)}`;
-    }
+  async ({ network, tokenAddress, page, limit, sort, orderBy }) => {
+    const endpoint = `/networks/${network}/pools/search?token_address=${encodeURIComponent(tokenAddress)}&page=${page}&limit=${limit}&sort=${sort}&order_by=${orderBy}`;
     const data = await fetchFromAPI(endpoint);
     return formatMcpResponse(data);
   }


### PR DESCRIPTION
## What does this PR do?

`dex_get_network_pools` and `dex_get_token_pools` return "Failed to fetch pools" on every call, on every network. Both hit DexPaprika endpoints that were removed and now return HTTP 410. Since `dexPaprikaRequest` turns any non-2xx into `null`, the agent never learns the endpoint is gone; it just sees a generic failure. `dex_get_network_pools` is the one whose own description says PRIMARY POOL FUNCTION.

I work on the DexPaprika API, so this is our removal breaking your tools. Sorry about that.

Reproduced against the current `main`:

```
$ curl -s -o /dev/null -w "%{http_code}\n" "https://api.dexpaprika.com/networks/bsc/pools?page=0&limit=10&sort=desc&order_by=volume_usd"
410
$ curl -s "https://api.dexpaprika.com/networks/bsc/pools?page=0&limit=10&sort=desc&order_by=volume_usd"
{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}

$ curl -s "https://api.dexpaprika.com/networks/bsc/tokens/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c/pools?page=0&limit=10"
{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}
```

Both now route to `/networks/{network}/pools/search`, which is the replacement the 410 body names. Token pools use the same endpoint with a `token_address` filter.

Three things ride along, all forced by the replacement's contract:

**The `orderBy` enum had to change.** `/pools/search` rejects the old values with a 400 that lists what it accepts:

```
$ curl -s "https://api.dexpaprika.com/networks/bsc/pools/search?limit=1&order_by=volume_usd"
{"message":"invalid query parameters: order_by (must be one of [volume_usd_24h volume_usd_7d volume_usd_30d liquidity_usd txns_24h created_at price_usd price_change_percentage_24h price_change_percentage_6h])"}
```

So `volume_usd` becomes `volume_usd_24h` (also the new default), `transactions` becomes `txns_24h`, and `last_price_change_usd_24h` becomes `price_change_percentage_24h`. `price_usd` and `created_at` were already valid and are unchanged.

**`reorder` and `pairedWith` are gone.** They were dropped with the old endpoint. The important detail is that `/pools/search` still returns 200 when you send them, it just ignores them, so leaving them in the schema would promise filtering that silently does not happen. I checked with a junk control:

```
$ curl -s ".../pools/search?token_address=0xC02a...&limit=1&order_by=volume_usd_24h" | jq -r '.results[0].id'
0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640
$ curl -s ".../pools/search?token_address=0xC02a...&address=0x0000000000000000000000000000000000000001&limit=1&order_by=volume_usd_24h" | jq -r '.results[0].id'
0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640
```

Same pool with a nonsense second-token filter, so the parameter is not being applied. I removed both rather than leave them looking functional. If you want that capability back, say so and I will look into what we can offer.

**The response key changes from `pools` to `results`**, and the shape gains `has_next_page` and `next_cursor`. Both tools pass the payload straight through `JSON.stringify`, so no unwrapping code needed changing, but anything downstream reading `.pools` from these two tools will need `.results`.

`dex_get_dex_pools` is deliberately untouched. `/networks/{network}/dexes/{dex}/pools` is still live, still returns the `pools` key, and still accepts the old `order_by` values, so changing it would have broken a working tool:

```
$ curl -s -o /dev/null -w "%{http_code}\n" "https://api.dexpaprika.com/networks/bsc/dexes/pancakeswap_v2/pools?page=0&limit=10&sort=desc&order_by=volume_usd"
200
```

I also applied the same two fixes to the second copy of this module at `src/vendors/dex-analytics/index.js`, which had the identical breakage in `getNetworkPools` and `getTokenPools`. The GeckoTerminal calls in `tools.ts` that also use a `/pools` path are a different API and are untouched.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Checklist

- [x] I've tested my changes
- [ ] I've updated documentation if needed
- [x] My code follows the project's style guidelines

On testing: I ran `npm run build`, which succeeds. I ran the exact URLs the patched tools now construct against the live API and got 200s with real pools back, and I checked all nine values of the new `orderBy` enum individually:

```
200  dex_get_network_pools (patched)   -> 10 pools, first: PancakeSwap V2 vol24h=305275462.18
200  dex_get_token_pools (patched)     -> 10 pools, first: PancakeSwap V3 vol24h=102153477.99
200  dex_get_dex_pools (UNCHANGED)     -> 10 pools, first: PancakeSwap V2 vol24h=274573089.26

enum check on /pools/search:
  200 volume_usd_24h   200 volume_usd_7d   200 volume_usd_30d
  200 liquidity_usd    200 txns_24h        200 created_at
  200 price_usd        200 price_change_percentage_24h
  200 price_change_percentage_6h
```

To be straight about what I did not do: I did not start the MCP server and drive these tools through a client, so the verification is at the HTTP layer, not the tool-invocation layer. `npm run typecheck` reports 434 errors on this repo, but that is the same count before and after my change, byte-identical error lists, and none are in either file I touched. I left the doc checkbox unticked because I could not find docs describing these two tools' parameters; point me at them and I will update them.

Happy to split this into two PRs if you would rather take the `src/modules` change and the `src/vendors` change separately.
